### PR TITLE
add OverrideMethod

### DIFF
--- a/src/Provide/Router/OverrideMethod.php
+++ b/src/Provide/Router/OverrideMethod.php
@@ -1,0 +1,117 @@
+<?php
+/**
+ * This file is part of the BEAR.Sunday package
+ *
+ * @license http://opensource.org/licenses/bsd-license.php BSD
+ */
+namespace BEAR\Sunday\Provide\Router;
+
+final class OverrideMethod
+{
+    /**
+     * Request method
+     *
+     * @var string
+     */
+    private $method;
+
+    /**
+     * HTTP Parameters
+     *
+     * @var array
+     */
+    private $query;
+
+    /**
+     * Return http method and queries
+     *
+     * 'queries' will change by method.
+     * get method return $_GET, post method return $_POST + $_GET
+     * patch | put | delete  return parsed 'php://input' value
+     *
+     * @param array $server $_SERVER
+     * @param array $get    $_GET
+     * @param array $post   $_POST
+     *
+     * @return array
+     */
+    public function get(array $server, array $get, array $post) {
+
+        // set the original value
+        $this->method = strtolower($server['REQUEST_METHOD']);
+
+        // early return on GET
+        if ($this->method === 'get') {
+            return [$this->method, $get];
+        }
+        // must be a POST to do an override
+        if ($this->method === 'post' && $this->methodOverRide($server, $post)) {
+            return [$this->method, $this->query];
+        }
+
+        // native method POST / PUT / PATCH / DELETE
+        return [$this->method, $this->getParams($this->method, $post)];
+    }
+
+    /**
+     * HTTP Method override
+     *
+     * @param array $server
+     * @param array $post
+     *
+     * @return bool is override ?
+     */
+    private function methodOverRide(array $server, array $post)
+    {
+        // look for override in post data
+        if (isset($post['_method'])) {
+            $this->method = strtolower($post['_method']);
+            unset($post['_method']);
+            $this->query = $post;
+
+            return true;
+        }
+
+        // look for override in headers
+        if (isset($server['HTTP_X_HTTP_METHOD_OVERRIDE'])) {
+            $this->method = strtolower($server['HTTP_X_HTTP_METHOD_OVERRIDE']);
+            $this->query = $post;
+
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Return request parameters
+     *
+     * @param string $method Request method
+     * @param array  $post   $_POST
+     *
+     * @return array
+     */
+    private function getParams($method, array $post)
+    {
+        if ($method === 'put' || $method === 'patch'  || $method === 'delete') {
+
+            return $this->getStdIn();
+        }
+
+        return $post;
+    }
+
+    /**
+     * Return stdin stream data
+     * 
+     * @return array
+     * @see http://php.net/manual/en/features.file-upload.put-method.php
+     */
+    private function getStdIn()
+    {
+        $input = file_get_contents('php://input');
+        $input ?  parse_str(file_get_contents('php://input'), $stdin) : $stdin = [];
+
+        return $stdin;
+    }
+}

--- a/src/Provide/Router/WebRouter.php
+++ b/src/Provide/Router/WebRouter.php
@@ -17,12 +17,8 @@ class WebRouter implements RouterInterface
     public function match(array $globals, array $server)
     {
         $request = new RouterMatch;
-        $method = strtolower($server['REQUEST_METHOD']);
-        list($request->method, $request->path, $request->query) = [
-            $method,
-            'page://self' . parse_url($server['REQUEST_URI'], PHP_URL_PATH),
-            ($method === 'get') ? $globals['_GET'] : $globals['_POST']
-        ];
+        list($request->method, $request->query) = (new OverrideMethod)->get($server, $globals['_GET'], $globals['_POST']);
+        $request->path = 'page://self' . parse_url($server['REQUEST_URI'], PHP_URL_PATH);
 
         return $request;
     }

--- a/tests/Provide/Router/OverrideMethodTest.php
+++ b/tests/Provide/Router/OverrideMethodTest.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace BEAR\Sunday\Provide\Router;
+
+require __DIR__ . '/file_get_contents.php';
+
+class OverrideMethodTest extends \PHPUnit_Framework_TestCase
+{
+    public function testGet()
+    {
+        $server = ['REQUEST_METHOD' => 'GET'];
+        $get = ['id' => '1'];
+        $post = [];
+        list($method, $params) = (new OverrideMethod)->get($server, $get, $post);
+        $this->assertSame('get', $method);
+        $this->assertSame(['id' => '1'], $params);
+    }
+
+    public function testPost()
+    {
+        $server = ['REQUEST_METHOD' => 'POST'];
+        $get = [];
+        $post = ['id' => '1'];
+        list($method, $params) = (new OverrideMethod)->get($server, $get, $post);
+        $this->assertSame('post', $method);
+        $this->assertSame(['id' => '1'], $params);
+    }
+
+    public function testPut()
+    {
+        $server = ['REQUEST_METHOD' => 'PUT'];
+        $get = ['name' => 'bear'];
+        $post = ['name' => 'sunday'];
+        list($method, $params) = (new OverrideMethod)->get($server, $get, $post);
+        $this->assertSame('put', $method);
+        $this->assertSame(['name' => 'kuma'], $params);
+    }
+
+    public function testPatch()
+    {
+        $server = ['REQUEST_METHOD' => 'PATCH'];
+        $get = ['name' => 'bear'];
+        $post = ['name' => 'sunday'];
+        list($method, $params) = (new OverrideMethod)->get($server, $get, $post);
+        $this->assertSame('patch', $method);
+        $this->assertSame(['name' => 'kuma'], $params);
+    }
+
+    public function testDelete()
+    {
+        $server = ['REQUEST_METHOD' => 'DELETE'];
+        $get = ['name' => 'bear'];
+        $post = ['name' => 'sunday'];
+        list($method, $params) = (new OverrideMethod)->get($server, $get, $post);
+        $this->assertSame('delete', $method);
+        $this->assertSame(['name' => 'kuma'], $params);
+    }
+
+    public function testOverridePut()
+    {
+        $server = ['REQUEST_METHOD' => 'POST'];
+        $get = ['name' => 'bear'];
+        $post = ['name' => 'sunday', '_method' => 'PUT'];
+        list($method, $params) = (new OverrideMethod)->get($server, $get, $post);
+        $this->assertSame('put', $method);
+        $this->assertSame(['name' => 'sunday'], $params);
+    }
+
+    public function testOverridePatch()
+    {
+        $server = ['REQUEST_METHOD' => 'POST'];
+        $get = ['name' => 'bear'];
+        $post = ['name' => 'sunday', '_method' => 'PATCH'];
+        list($method, $params) = (new OverrideMethod)->get($server, $get, $post);
+        $this->assertSame('patch', $method);
+        $this->assertSame(['name' => 'sunday'], $params);
+    }
+
+    public function testOverrideDelete()
+    {
+        $server = ['REQUEST_METHOD' => 'POST'];
+        $get = ['name' => 'bear'];
+        $post = ['name' => 'sunday', '_method' => 'DELETE'];
+        list($method, $params) = (new OverrideMethod)->get($server, $get, $post);
+        $this->assertSame('delete', $method);
+        $this->assertSame(['name' => 'sunday'], $params);
+    }
+
+    public function testOverrideHeaderPut()
+    {
+        $server = ['REQUEST_METHOD' => 'POST', 'HTTP_X_HTTP_METHOD_OVERRIDE' => 'PUT'];
+        $get = ['name' => 'bear'];
+        $post = ['name' => 'sunday'];
+        list($method, $params) = (new OverrideMethod)->get($server, $get, $post);
+        $this->assertSame('put', $method);
+        $this->assertSame(['name' => 'sunday'], $params);
+    }
+
+    public function testOverrideHeaderPatch()
+    {
+        $server = ['REQUEST_METHOD' => 'POST', 'HTTP_X_HTTP_METHOD_OVERRIDE' => 'PATCH'];
+        $get = ['name' => 'bear'];
+        $post = ['name' => 'sunday'];
+        list($method, $params) = (new OverrideMethod)->get($server, $get, $post);
+        $this->assertSame('patch', $method);
+        $this->assertSame(['name' => 'sunday'], $params);
+    }
+
+    public function testOverrideHeaderDelete()
+    {
+        $server = ['REQUEST_METHOD' => 'POST', 'HTTP_X_HTTP_METHOD_OVERRIDE' => 'DELETE'];
+        $get = ['name' => 'bear'];
+        $post = ['name' => 'sunday'];
+        list($method, $params) = (new OverrideMethod)->get($server, $get, $post);
+        $this->assertSame('delete', $method);
+        $this->assertSame(['name' => 'sunday'], $params);
+    }
+}

--- a/tests/Provide/Router/WebRouterTest.php
+++ b/tests/Provide/Router/WebRouterTest.php
@@ -18,7 +18,8 @@ class WebRouterTest extends \PHPUnit_Framework_TestCase
     public function testMatchRoot()
     {
         $global = [
-            '_GET' => []
+            '_GET' => [],
+            '_POST' => []
         ];
         $server = [
             'REQUEST_METHOD' => 'GET',
@@ -36,8 +37,8 @@ class WebRouterTest extends \PHPUnit_Framework_TestCase
         $global = [
             '_GET' => [
                 'id' => 1
-
-            ]
+            ],
+            '_POST' => []
         ];
         $server = [
             'REQUEST_METHOD' => 'GET',

--- a/tests/Provide/Router/file_get_contents.php
+++ b/tests/Provide/Router/file_get_contents.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace BEAR\Sunday\Provide\Router;
+
+function file_get_contents($filename, $flags = null, $context = null, $offset = null, $maxlen = null)
+{
+    return "name=kuma";
+}


### PR DESCRIPTION
This PR is about...
- how to determine HTTP method
- what parameters will be passed to resource object request method
- merge `$_GET` value in POST
### '_method' override

``` php
// a POST with the field '_method' will use the _method value instead of POST
$_SERVER['REQUEST_METHOD'] = 'POST'; // must be POST request to override
$_POST['_method'] = 'PUT';
$_POST['id'] = '1';

// called method
public function onPut($id) // '1'
```
### HTTP_X_HTTP_METHOD_OVERRIDE override

``` php
$_SERVER['REQUEST_METHOD'] = 'POST'; // must be POST request to override
$_SERVER['HTTP_X_HTTP_METHOD_OVERRIDE'] = 'PUT';
$_POST['id'] = '1';

// called method
public function onPut($id) // '1'
```
### 'php://input' for native PUT / PATCH / DELETE method

``` php
parse_str(file_get_contents('php://input'), $put) // name=bear
$_SERVER['REQUEST_METHOD'] = 'PUT';

// called method
public function onPut($name) // 'bear'
```
