### PR TITLE
Respect response's status code

### DIFF
--- a/src/Provide/Transfer/HttpResponder.php
+++ b/src/Provide/Transfer/HttpResponder.php
@@ -22,13 +22,13 @@ class HttpResponder implements TransferInterface
             $resourceObject->toString();
         }
 
-        // code
-        http_response_code($resourceObject->code);
-
         // header
         foreach ($resourceObject->headers as $label => $value) {
             header("{$label}: {$value}", false);
         }
+
+        // code
+        http_response_code($resourceObject->code);
 
         // body
         echo $resourceObject->view;


### PR DESCRIPTION
Passing `WWW-Authenticate` to `header()` overwrites the status code to 401.

https://github.com/php/php-src/blob/a51cb393b1accc29200e8f57ef867a6a47b2564f/main/SAPI.c#L829

According to RFC it is said that it is also possible to include `WWW-Authenticate` in status codes other than 401.

https://tools.ietf.org/html/rfc7235#page-7

> A server MAY generate a WWW-Authenticate header field in other response.

Since OAuth 2.0 Bearer writes its contents in `WWW-Authenticate` header even for errors other than 401, the original status code is applied after the status code reaches 401 by inserting the `WWW-Authenticate` header field is necessary.

https://tools.ietf.org/html/rfc6750#page-9

----

401 以外のステータスコードでも `WWW-Authenticate` ヘッダを挿入できるように。

`header()` に `WWW-Authenticate` を渡すとステータスコードが 401 に上書きされます。

https://github.com/php/php-src/blob/a51cb393b1accc29200e8f57ef867a6a47b2564f/main/SAPI.c#L829

RFC によれば 401 以外のステータスコードでも `WWW-Authenticate` を含めてもよいとされています。

https://tools.ietf.org/html/rfc7235#page-7

> A server MAY generate a WWW-Authenticate header field in other response.

OAuth 2.0 Bearer では 401 以外のエラーでもその内容を `WWW-Authenticate` ヘッダ記述するため、`WWW-Authenticate` ヘッダを挿入したことによってステータスコードが 401 になった後、本来のステータスコードが適用される必要があります。

https://tools.ietf.org/html/rfc6750#page-9