### PR TITLE
Define HttpCacheInterface to support RFC 7234 HTTP Cache

### DIFF
--- a/src/Extension/Transfer/HttpCacheInterface.php
+++ b/src/Extension/Transfer/HttpCacheInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of the BEAR.Sunday package.
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ */
+namespace BEAR\Sunday\Extension\Transfer;
+
+interface HttpCacheInterface
+{
+    /**
+     * Is not modified ? (RFC7232 4.1)
+     *
+     * Indicates that a conditional GET or HEAD request has been received and would have resulted in a 200
+     * (OK) response if it were not for the fact that the condition evaluated to false.
+     *
+     * @https://tools.ietf.org/html/rfc7232#section-4.1
+     */
+    public function isNotModified(array $server) : bool;
+
+    /**
+     * Transfer status code 304 to the client
+     */
+    public function transfer();
+}

--- a/src/Module/SundayModule.php
+++ b/src/Module/SundayModule.php
@@ -14,6 +14,7 @@ use BEAR\Sunday\Module\Resource\ResourceModule;
 use BEAR\Sunday\Provide\Application\AppModule;
 use BEAR\Sunday\Provide\Error\ErrorModule;
 use BEAR\Sunday\Provide\Router\RouterModule;
+use BEAR\Sunday\Provide\Transfer\HttpCacheModule;
 use BEAR\Sunday\Provide\Transfer\HttpResponderModule;
 use Ray\Di\AbstractModule;
 
@@ -25,6 +26,7 @@ class SundayModule extends AbstractModule
     protected function configure()
     {
         $this->install(new AppModule);
+        $this->install(new HttpCacheModule);
         $this->install(new DoctrineCacheModule);
         $this->install(new DoctrineAnnotationModule);
         $this->install(new ResourceModule);

--- a/src/Provide/Transfer/HttpCacheModule.php
+++ b/src/Provide/Transfer/HttpCacheModule.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of the BEAR.Sunday package.
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ */
+namespace BEAR\Sunday\Provide\Transfer;
+
+use BEAR\Sunday\Extension\Transfer\HttpCacheInterface;
+use BEAR\Sunday\Provide\Transfer\NullHttpCache;
+use Ray\Di\AbstractModule;
+
+class HttpCacheModule extends AbstractModule
+{
+    protected function configure()
+    {
+        $this->bind(HttpCacheInterface::class)->to(NullHttpCache::class);
+    }
+}

--- a/src/Provide/Transfer/HttpCacheModule.php
+++ b/src/Provide/Transfer/HttpCacheModule.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 namespace BEAR\Sunday\Provide\Transfer;
 
 use BEAR\Sunday\Extension\Transfer\HttpCacheInterface;
-use BEAR\Sunday\Provide\Transfer\NullHttpCache;
 use Ray\Di\AbstractModule;
 
 class HttpCacheModule extends AbstractModule

--- a/src/Provide/Transfer/NullHttpCache.php
+++ b/src/Provide/Transfer/NullHttpCache.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of the BEAR.Sunday package.
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ */
+namespace BEAR\Sunday\Provide\Transfer;
+
+use BEAR\Sunday\Extension\Transfer\HttpCacheInterface;
+
+final class NullHttpCache implements HttpCacheInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function isNotModified(array $server) : bool
+    {
+        return false;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function transfer()
+    {
+    }
+}


### PR DESCRIPTION
Define [RFC 7234](https://www.google.co.jp/search?q=RFC+7234%2C&oq=RFC+7234%2C&aqs=chrome..69i57j35i39l2j0l2.430j0j7&sourceid=chrome&ie=UTF-8) HTTP cache interface. But no actual implementation given in this package, Only `NullHttpCache` is given.

```php
namespace BEAR\Sunday\Extension\Transfer;

interface HttpCacheInterface
{
    /**
     * Is not modified ? (RFC7232 4.1)
     *
     * Indicates that a conditional GET or HEAD request has been received and would have resulted in a 200
     * (OK) response if it were not for the fact that the condition evaluated to false.
     *
     * @https://tools.ietf.org/html/rfc7232#section-4.1
     */
    public function isNotModified(array $server) : bool;

    /**
     * Transfer status code 304 to the client
     */
    public function transfer();
}
```