### PR TITLE
Return `304 not modified` If Etag is match.

### DIFF
--- a/src/Provide/Transfer/HttpResponder.php
+++ b/src/Provide/Transfer/HttpResponder.php
@@ -14,6 +14,10 @@ class HttpResponder implements TransferInterface
      */
     public function __invoke(ResourceObject $ro, array $server)
     {
+        if ($this->respondeIfETagMatch($ro, $server)) {
+            return;
+        }
+
         unset($server);
         // render
         if (! $ro->view) {
@@ -30,5 +34,39 @@ class HttpResponder implements TransferInterface
 
         // body
         echo $ro->view;
+    }
+
+    private function respondeIfETagMatch(ResourceObject $ro, array $server) : bool
+    {
+        if (! isset($server['HTTP_IF_NONE_MATCH'])
+            || ! isset($ro->headers['ETag'])
+            || $server['HTTP_IF_NONE_MATCH'] !== $ro->headers['ETag']
+        ) {
+            return false;
+        }
+
+        // See: https://httpwg.org/specs/rfc7232.html#status.304
+        $mustGenerateHeaders = [
+            'Cache-Control',
+            'Content-Location',
+            'Date',
+            'ETag',
+            'Expires',
+            'Vary',
+        ];
+
+        // header
+        foreach ($ro->headers as $label => $value) {
+            if (! in_array($label, $mustGenerateHeaders, true)) {
+                continue;
+            }
+
+            header("{$label}: {$value}", false);
+        }
+
+        // code
+        http_response_code(304);
+
+        return true;
     }
 }

--- a/tests/Fake/Provide/Transfer/FakeHttpResponder.php
+++ b/tests/Fake/Provide/Transfer/FakeHttpResponder.php
@@ -24,13 +24,55 @@ class FakeHttpResponder implements TransferInterface
 
     public function __invoke(ResourceObject $ro, array $server)
     {
+        if ($this->respondeIfETagMatch($ro, $server)) {
+            return;
+        }
+
+        // render
         if (! $ro->view) {
             self::$body = $ro->toString();
         }
+
         // header
         foreach ($ro->headers as $label => $value) {
             header("{$label}: {$value}", false);
         }
-        self::$code = $ro->code;
+
+        // code
+        http_response_code($ro->code);
+    }
+
+    private function respondeIfETagMatch(ResourceObject $ro, array $server) : bool
+    {
+        if (! isset($server['HTTP_IF_NONE_MATCH'])
+            || ! isset($ro->headers['ETag'])
+            || $server['HTTP_IF_NONE_MATCH'] !== $ro->headers['ETag']
+        ) {
+            return false;
+        }
+
+        // See: https://httpwg.org/specs/rfc7232.html#status.304
+        $mustGenerateHeaders = [
+            'Cache-Control',
+            'Content-Location',
+            'Date',
+            'ETag',
+            'Expires',
+            'Vary',
+        ];
+
+        // header
+        foreach ($ro->headers as $label => $value) {
+            if (! in_array($label, $mustGenerateHeaders, true)) {
+                continue;
+            }
+
+            header("{$label}: {$value}", false);
+        }
+
+        // code
+        http_response_code(304);
+
+        return true;
     }
 }

--- a/tests/Fake/Provide/Transfer/http_response_code.php
+++ b/tests/Fake/Provide/Transfer/http_response_code.php
@@ -4,6 +4,6 @@ namespace BEAR\Sunday\Provide\Transfer;
 
 function http_response_code($int)
 {
-    FakeHttpResponder::$code = func_get_args();
+    FakeHttpResponder::$code = $int;
     unset($int);
 }

--- a/tests/Provide/Transfer/HttpResponderTest.php
+++ b/tests/Provide/Transfer/HttpResponderTest.php
@@ -70,7 +70,7 @@ class HttpResponderTest extends TestCase
             ['ETag: etag-x', false],
         ];
         $this->assertSame($expectedArgs, FakeHttpResponder::$headers);
-        $expect = null;
+        $expect = '';
         $actual = FakeHttpResponder::$body;
         $this->assertSame($expect, $actual);
         $this->assertSame(304, FakeHttpResponder::$code);

--- a/tests/Provide/Transfer/HttpResponderTest.php
+++ b/tests/Provide/Transfer/HttpResponderTest.php
@@ -59,4 +59,38 @@ class HttpResponderTest extends TestCase
         $actual = FakeHttpResponder::$body;
         $this->assertSame($expect, $actual);
     }
+
+    public function testTransferETagIsMatch()
+    {
+        $ro = (new FakeResource)->onGet();
+        $ro->headers['ETag'] = 'etag-x';
+        $ro->transfer($this->responder, ['HTTP_IF_NONE_MATCH' => 'etag-x']);
+        $expectedArgs = [
+            ['Cache-Control: max-age=0', false],
+            ['ETag: etag-x', false],
+        ];
+        $this->assertSame($expectedArgs, FakeHttpResponder::$headers);
+        $expect = null;
+        $actual = FakeHttpResponder::$body;
+        $this->assertSame($expect, $actual);
+        $this->assertSame(304, FakeHttpResponder::$code);
+    }
+
+    public function testTransferETagIsNotMatch()
+    {
+        $ro = (new FakeResource)->onGet();
+        $ro->headers['ETag'] = 'etag-y';
+        $ro->transfer($this->responder, ['HTTP_IF_NONE_MATCH' => 'etag-x']);
+        $expectedArgs = [
+            ['Cache-Control: max-age=0', false],
+            ['ETag: etag-y', false],
+            ['content-type: application/json', false],
+        ];
+;
+        $this->assertSame($expectedArgs, FakeHttpResponder::$headers);
+        $expect = '{"greeting":"hello world"}';
+        $actual = FakeHttpResponder::$body;
+        $this->assertSame($expect, $actual);
+        $this->assertSame(200, FakeHttpResponder::$code);
+    }
 }


### PR DESCRIPTION
See: https://github.com/bearsunday/BEAR.QueryRepository/pull/56#issuecomment-447738405

`If-None-Match` ヘッダを検証し、 `Etag` の値が一致していれば、ステータスコード 304 を返し、body は返さないようにしました。
ネットワーク帯域を節約することが目的です。

