### PR TITLE
Extract Header class

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
   ],
   "require": {
       "php": ">=7.1.0",
+      "ext-json": "*",
       "bear/resource": "^1.12"
   },
   "require-dev": {

--- a/src/Exception/BadRequestJsonException.php
+++ b/src/Exception/BadRequestJsonException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\Sunday\Exception;
+
+use BEAR\Resource\Exception\BadRequestException;
+
+class BadRequestJsonException extends BadRequestException implements ExceptionInterface
+{
+}

--- a/src/Provide/Router/WebRouter.php
+++ b/src/Provide/Router/WebRouter.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace BEAR\Sunday\Provide\Router;
 
-use BEAR\Resource\Exception\BadRequestException;
 use BEAR\Sunday\Annotation\DefaultSchemeHost;
+use BEAR\Sunday\Exception\BadRequestJsonException;
 use BEAR\Sunday\Extension\Router\RouterInterface;
 use BEAR\Sunday\Extension\Router\RouterMatch;
 use function is_array;
@@ -70,7 +70,7 @@ final class WebRouter implements RouterInterface
         $content = json_decode($rawBody, true);
         $error = json_last_error();
         if ($error !== JSON_ERROR_NONE) {
-            throw new BadRequestException(json_last_error_msg());
+            throw new BadRequestJsonException(json_last_error_msg());
         }
 
         return $content;

--- a/src/Provide/Transfer/Header.php
+++ b/src/Provide/Transfer/Header.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\Sunday\Provide\Transfer;
+
+use BEAR\Resource\ResourceObject;
+
+final class Header implements HeaderInterface
+{
+    public function __invoke(ResourceObject $ro, array $server) : void
+    {
+        foreach ($ro->headers as $label => $value) {
+            header("{$label}: {$value}", false);
+        }
+    }
+}

--- a/src/Provide/Transfer/HeaderInterface.php
+++ b/src/Provide/Transfer/HeaderInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\Sunday\Provide\Transfer;
+
+use BEAR\Resource\ResourceObject;
+
+interface HeaderInterface
+{
+    public function __invoke(ResourceObject $ro, array $server) : void;
+}

--- a/src/Provide/Transfer/HttpResponder.php
+++ b/src/Provide/Transfer/HttpResponder.php
@@ -10,6 +10,16 @@ use BEAR\Sunday\Extension\Transfer\TransferInterface;
 class HttpResponder implements TransferInterface
 {
     /**
+     * @var HeaderInterface
+     */
+    private $header;
+
+    public function __construct(HeaderInterface $header)
+    {
+        $this->header = $header;
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function __invoke(ResourceObject $ro, array $server)
@@ -26,9 +36,7 @@ class HttpResponder implements TransferInterface
         }
 
         // header
-        foreach ($ro->headers as $label => $value) {
-            header("{$label}: {$value}", false);
-        }
+        ($this->header)($ro, $server);
 
         // code
         http_response_code($ro->code);
@@ -39,9 +47,7 @@ class HttpResponder implements TransferInterface
 
     private function isNotModified(ResourceObject $ro, array $server) : bool
     {
-        return isset($server['HTTP_IF_NONE_MATCH'], $ro->headers['ETag'])
-
-            && $server['HTTP_IF_NONE_MATCH'] === $ro->headers['ETag'];
+        return isset($server['HTTP_IF_NONE_MATCH'], $ro->headers['ETag']) && $server['HTTP_IF_NONE_MATCH'] === $ro->headers['ETag'];
     }
 
     /**

--- a/src/Provide/Transfer/HttpResponderModule.php
+++ b/src/Provide/Transfer/HttpResponderModule.php
@@ -15,5 +15,6 @@ class HttpResponderModule extends AbstractModule
     protected function configure()
     {
         $this->bind(TransferInterface::class)->to(HttpResponder::class);
+        $this->bind(HeaderInterface::class)->to(Header::class);
     }
 }

--- a/tests/Provide/Error/VndErrorTest.php
+++ b/tests/Provide/Error/VndErrorTest.php
@@ -9,6 +9,7 @@ use BEAR\Resource\Exception\ResourceNotFoundException;
 use BEAR\Resource\Exception\ServerErrorException;
 use BEAR\Sunday\Extension\Router\RouterMatch;
 use BEAR\Sunday\Provide\Transfer\FakeHttpResponder;
+use BEAR\Sunday\Provide\Transfer\Header;
 use PHPUnit\Framework\TestCase;
 
 class VndErrorTest extends TestCase
@@ -23,7 +24,7 @@ class VndErrorTest extends TestCase
     protected function setUp() : void
     {
         FakeHttpResponder::reset();
-        $this->vndError = new VndError(new FakeHttpResponder);
+        $this->vndError = new VndError(new FakeHttpResponder(new Header));
         ini_set('error_log', '/dev/null');
     }
 

--- a/tests/Provide/Transfer/HttpResponderTest.php
+++ b/tests/Provide/Transfer/HttpResponderTest.php
@@ -17,7 +17,7 @@ class HttpResponderTest extends TestCase
     protected function setUp() : void
     {
         parent::setUp();
-        $this->responder = new FakeHttpResponder;
+        $this->responder = new FakeHttpResponder(new Header);
         FakeHttpResponder::reset();
     }
 


### PR DESCRIPTION
You can customize header output freely in the class that implements `HeaderInterface.` This is ideal for custom `CORS` output.