### PR TITLE
Add RouterInterface type Globals and Server

### DIFF
--- a/src/Extension/Router/RouterInterface.php
+++ b/src/Extension/Router/RouterInterface.php
@@ -6,11 +6,26 @@ namespace BEAR\Sunday\Extension\Router;
 
 use BEAR\Sunday\Extension\ExtensionInterface;
 
+/**
+ * @psalm-type Globals = array{
+ *     _GET: array<string, string|array>,
+ *     _POST: array<string, string|array>
+ * }
+ * @psalm-type Server = array{
+ *     REQUEST_URI: string,
+ *     REQUEST_METHOD: string,
+ *     CONTENT_TYPE?: string,
+ *     HTTP_CONTENT_TYPE?: string,
+ *     HTTP_RAW_POST_DATA?: string
+ * }
+ */
 interface RouterInterface extends ExtensionInterface
 {
     /**
-     * @param array{_GET: array<string, string|array>, _POST: array<string, string|array>} $globals $GLOBALS
-     * @param array<string, mixed>                                                         $server  $_SERVER
+     * @psalm-param Globals $globals
+     * @psalm-param Server  $server
+     * @phpstan-param array<string, mixed> $globals
+     * @phpstan-param array<string, mixed> $server
      *
      * @return RouterMatch
      */

--- a/src/Inject/PsrLoggerInject.php
+++ b/src/Inject/PsrLoggerInject.php
@@ -14,7 +14,7 @@ trait PsrLoggerInject
     private $logger;
 
     /**
-     * @Ray\Di\Di\Inject
+     * @\Ray\Di\Di\Inject
      */
     public function setPsrLogger(LoggerInterface $logger)
     {

--- a/src/Inject/ResourceInject.php
+++ b/src/Inject/ResourceInject.php
@@ -14,7 +14,7 @@ trait ResourceInject
     protected $resource;
 
     /**
-     * @Ray\Di\Di\Inject
+     * @\Ray\Di\Di\Inject
      */
     public function setResource(ResourceInterface $resource)
     {

--- a/src/Provide/Router/WebRouter.php
+++ b/src/Provide/Router/WebRouter.php
@@ -8,11 +8,14 @@ use BEAR\Sunday\Annotation\DefaultSchemeHost;
 use BEAR\Sunday\Exception\BadRequestJsonException;
 use BEAR\Sunday\Extension\Router\RouterInterface;
 use BEAR\Sunday\Extension\Router\RouterMatch;
-use function is_array;
 use function parse_str;
 use function parse_url;
 use function strtolower;
 
+/**
+ * @psalm-import-type Globals from RouterInterface
+ * @psalm-import-type Server from RouterInterface
+ */
 final class WebRouter implements RouterInterface
 {
     /**
@@ -33,8 +36,6 @@ final class WebRouter implements RouterInterface
      */
     public function match(array $globals, array $server)
     {
-        assert(isset($server['REQUEST_METHOD']) && is_string($server['REQUEST_METHOD']));
-        assert(isset($server['REQUEST_URI']) && is_string($server['REQUEST_URI']));
         $method = strtolower($server['REQUEST_METHOD']);
         $match = new RouterMatch;
         $match->method = $method;
@@ -55,15 +56,16 @@ final class WebRouter implements RouterInterface
     /**
      * Return request query by media-type
      *
-     * @param array{CONTENT_TYPE?: string, HTTP_CONTENT_TYPE?: string, HTTP_RAW_POST_DATA?: string} $server
-     * @param array<string, mixed>                                                                  $globals
+     * @psalm-param Server $server
+     * @psalm-param Globals $globals
+     * @phpstan-param array<string, mixed> $globals
+     * @phpstan-param array<string, mixed> $server
      *
      * @return array<string, mixed> $globals
      */
     private function getUnsafeQuery(string $method, array $globals, array $server) : array
     {
-        if ($method === 'post' && is_array($globals['_POST'])) {
-            /** @var array<string, mixed> $globals['_POST'] */
+        if ($method === 'post') {
             return $globals['_POST'];
         }
         $contentType = $server['CONTENT_TYPE'] ?? ($server['HTTP_CONTENT_TYPE']) ?? '';


### PR DESCRIPTION
Define custom type in `BEAR\Sunday\RouterInterface`:

```php
/**
 * @psalm-type Globals = array{
 *     _GET: array<string, string|array>,
 *     _POST: array<string, string|array>
 * }
 * @psalm-type Server = array{
 *     REQUEST_URI: string,
 *     REQUEST_METHOD: string,
 *     CONTENT_TYPE?: string,
 *     HTTP_CONTENT_TYPE?: string,
 *     HTTP_RAW_POST_DATA?: string
 * }
 */
```

You can import and use those type in the another class.

```php
/**
 * @psalm-import-type Globals from RouterInterface
 * @psalm-import-type Server from RouterInterface
 */
final class Bootstrap
{
    /**
     * @psalm-param Globals $globals
     * @psalm-param Server  $server
     */
    public function __invoke(array $globals, array $server) : int
    {
```