### PR TITLE
Add Throwable handler

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -7,12 +7,12 @@
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
 >
     <projectFiles>
-        <directory name="src" />
+        <directory name="src"/>
         <ignoreFiles>
-            <directory name="vendor" />
+            <directory name="vendor"/>
         </ignoreFiles>
     </projectFiles>
     <issueHandlers>
-        <MissingConstructor errorLevel="suppress" />
+        <MissingConstructor errorLevel="suppress"/>
     </issueHandlers>
 </psalm>

--- a/src/Extension/Error/ThrowableHandlerInterface.php
+++ b/src/Extension/Error/ThrowableHandlerInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\Sunday\Extension\Error;
+
+use BEAR\Sunday\Extension\Router\RouterMatch as Request;
+use Throwable;
+
+interface ThrowableHandlerInterface
+{
+    /**
+     * Handle Throwable
+     */
+    public function handle(Throwable $e, Request $request) : self;
+
+    /**
+     * Transfer error page
+     */
+    public function transfer() : void;
+}

--- a/src/Provide/Error/ErrorModule.php
+++ b/src/Provide/Error/ErrorModule.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace BEAR\Sunday\Provide\Error;
 
 use BEAR\Sunday\Extension\Error\ErrorInterface;
+use BEAR\Sunday\Extension\Error\ThrowableHandlerInterface;
+use BEAR\Sunday\Extension\Provide\ThrowableHandler;
 use Ray\Di\AbstractModule;
 
 class ErrorModule extends AbstractModule
@@ -15,5 +17,6 @@ class ErrorModule extends AbstractModule
     protected function configure() : void
     {
         $this->bind(ErrorInterface::class)->to(VndError::class);
+        $this->bind(ThrowableHandlerInterface::class)->to(ThrowableHandler::class);
     }
 }

--- a/src/Provide/Error/ErrorModule.php
+++ b/src/Provide/Error/ErrorModule.php
@@ -6,7 +6,6 @@ namespace BEAR\Sunday\Provide\Error;
 
 use BEAR\Sunday\Extension\Error\ErrorInterface;
 use BEAR\Sunday\Extension\Error\ThrowableHandlerInterface;
-use BEAR\Sunday\Extension\Provide\ThrowableHandler;
 use Ray\Di\AbstractModule;
 
 class ErrorModule extends AbstractModule

--- a/src/Provide/Error/ThrowableHandler.php
+++ b/src/Provide/Error/ThrowableHandler.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\Sunday\Provide\Error;
+
+use BEAR\Sunday\Extension\Error\ErrorInterface;
+use BEAR\Sunday\Extension\Error\ThrowableHandlerInterface;
+use BEAR\Sunday\Extension\Router\RouterMatch as Request;
+use const E_ERROR;
+use Error;
+use ErrorException;
+use Exception;
+use Throwable;
+
+final class ThrowableHandler implements ThrowableHandlerInterface
+{
+    /**
+     * @var ErrorInterface
+     */
+    private $error;
+
+    public function __construct(ErrorInterface $error)
+    {
+        $this->error = $error;
+    }
+
+    public function handle(Throwable $e, Request $request) : ThrowableHandlerInterface
+    {
+        $e = $e instanceof Error ? new ErrorException($e->getMessage(), (int) $e->getCode(), E_ERROR, $e->getFile(), $e->getLine()) : $e;
+        assert($e instanceof Exception);
+        $this->error->handle($e, $request);
+
+        return $this;
+    }
+
+    public function transfer() : void
+    {
+        $this->error->transfer();
+    }
+}

--- a/src/Provide/Transfer/HttpResponder.php
+++ b/src/Provide/Transfer/HttpResponder.php
@@ -52,6 +52,7 @@ class HttpResponder implements TransferInterface
     private function getOutput(ResourceObject $ro, array $server) : Output
     {
         $ro->toString(); // render and set headers
+
         return new Output($ro->code, ($this->header)($ro, $server), $ro->view ?: $ro->toString());
     }
 }

--- a/tests/Provide/Error/ThrowableHandlerTest.php
+++ b/tests/Provide/Error/ThrowableHandlerTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\Sunday\Provide\Error;
+
+use BEAR\Resource\Exception\ResourceNotFoundException;
+use BEAR\Sunday\Extension\Router\RouterMatch;
+use BEAR\Sunday\Provide\Transfer\ConditionalResponse;
+use BEAR\Sunday\Provide\Transfer\FakeHttpResponder;
+use BEAR\Sunday\Provide\Transfer\Header;
+use Exception;
+use PHPUnit\Framework\TestCase;
+
+class ThrowableHandlerTest extends TestCase
+{
+    /**
+     * @var int
+     */
+    public static $code;
+
+    /**
+     * @var ThrowableHandler
+     */
+    private $throableHandler;
+
+    protected function setUp() : void
+    {
+        FakeHttpResponder::reset();
+        $this->throableHandler = new ThrowableHandler(new VndError(new FakeHttpResponder(new Header, new ConditionalResponse)));
+        ini_set('error_log', '/dev/null');
+    }
+
+    public function testException() : void
+    {
+        $e = new ResourceNotFoundException('', 404);
+        $this->throableHandler->handle($e, new RouterMatch)->transfer();
+        $this->assertSame(404, FakeHttpResponder::$code);
+        $this->assertSame([['Content-Type: application/vnd.error+json', false]], FakeHttpResponder::$headers);
+        $this->assertSame('{"message":"Not Found"}', FakeHttpResponder::$body);
+    }
+
+    public function testError() : void
+    {
+        try {
+            1 / 0;
+        } catch (Exception $e) {
+        }
+        $this->throableHandler->handle($e, new RouterMatch)->transfer();
+        $this->assertSame(500, FakeHttpResponder::$code);
+        $this->assertSame([['Content-Type: application/vnd.error+json', false]], FakeHttpResponder::$headers);
+        $this->assertSame('{"message":"500 Server Error"}', FakeHttpResponder::$body);
+    }
+}

--- a/tests/Provide/Error/ThrowableHandlerTest.php
+++ b/tests/Provide/Error/ThrowableHandlerTest.php
@@ -43,10 +43,10 @@ class ThrowableHandlerTest extends TestCase
     public function testError() : void
     {
         try {
-            1 / 0;
+            1 / 0; // @phpstan-ignore-line
         } catch (Exception $e) {
         }
-        $this->throableHandler->handle($e, new RouterMatch)->transfer();
+        $this->throableHandler->handle($e, new RouterMatch)->transfer(); // @phpstan-ignore-line
         $this->assertSame(500, FakeHttpResponder::$code);
         $this->assertSame([['Content-Type: application/vnd.error+json', false]], FakeHttpResponder::$headers);
         $this->assertSame('{"message":"500 Server Error"}', FakeHttpResponder::$body);


### PR DESCRIPTION
You can update the exception handler to the throwable handler as follows.

before

```php
        try {
            // ...
        } catch (Exception $e) {
            $app->error->handle($e, $request)->transfer();

            return 1;
        }
```

after

```php
        try {
            // ...
        } catch (Throwable $e) {
            $app->throwableHandler->handle($e, $request)->transfer();

            return 1;
        }
```

with your new App as follows.

```php
final class App implements AppInterface
{
    /** @var HttpCacheInterface */
    public $httpCache;

    /** @var RouterInterface */
    public $router;

    /** @var TransferInterface */
    public $responder;

    /** @var ResourceInterface */
    public $resource;

    /** @var ThrowableHandlerInterface */
    public $throwableHandler;

    public function __construct(
        HttpCacheInterface $httpCache,
        RouterInterface $router,
        TransferInterface $responder,
        ResourceInterface $resource,
        ThrowableHandlerInterface $throwableHandler,
        ErrorInterface $error
    ) {
        $this->httpCache = $httpCache;
        $this->router = $router;
        $this->responder = $responder;
        $this->resource = $resource;
        $this->throwableHandler = $throwableHandler;
    }
}
```