### PR TITLE
Update CI workflow to use v1 and adjust PHP versions

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   ci:
-    uses: ray-di/.github/.github/workflows/continuous-integration.yml@next_stable
+    uses: ray-di/.github/.github/workflows/continuous-integration.yml@v1
     with:
-      old_stable: '["8.0", "8.1", "8.2", "8.3"]'
+      old_stable: '["8.1", "8.2", "8.3"]'
       current_stable: 8.4


### PR DESCRIPTION
Switched the CI workflow reference from `next_stable` to `v1` for stability. Removed PHP 8.0 from the `old_stable` versions list to align with updated support requirements.