### PR TITLE
Add PHP 8.5 support

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -9,5 +9,5 @@ jobs:
   ci:
     uses: ray-di/.github/.github/workflows/continuous-integration.yml@v1
     with:
-      old_stable: '["8.1", "8.2", "8.3"]'
-      current_stable: 8.4
+      old_stable: '["8.1", "8.2", "8.3", "8.4"]'
+      current_stable: 8.5


### PR DESCRIPTION
## Summary
- Update CI workflow to include PHP 8.5 as current stable version
- Move PHP 8.4 to old_stable versions list

## Test plan
- [x] CI workflow updated with PHP 8.5
- [ ] Verify all tests pass on PHP 8.5 in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Update continuous integration configuration to support PHP 8.5 and reclassify PHP 8.4 as old stable

CI:
- Include PHP 8.5 as the current stable version in the CI workflow
- Add PHP 8.4 to the list of old stable versions