### PR TITLE
Fix static analysis error in NamedModule

### DIFF
--- a/src/Module/Constant/NamedModule.php
+++ b/src/Module/Constant/NamedModule.php
@@ -9,7 +9,7 @@ use Ray\Di\AbstractModule;
 
 final class NamedModule extends AbstractModule
 {
-    /** @param array<string, string> $names */
+    /** @param array<non-empty-string, string> $names */
     public function __construct(
         private array $names,
     ) {


### PR DESCRIPTION
## Summary
- Update PHPDoc type annotation from `array<string, string>` to `array<non-empty-string, string>` in `NamedModule`
- Fixes `Ray\Di\Bind::annotatedWith()` parameter type mismatch detected by Psalm and PHPStan

## Test plan
- [x] Psalm passes locally
- [x] PHPStan passes locally
- [x] All tests pass