### PR TITLE
Handle JsonSchemaRequestException as 400 Bad Request in ThrowableHandler

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     ],
     "require": {
         "php": "^8.2",
-        "bear/resource": "^1.16",
+        "bear/resource": "^1.33",
         "psr/log": "^1.1 || ^2.0 || ^3.0",
         "ray/aop": "^2.12.3",
         "ray/di": "^2.13",

--- a/src/Provide/Error/ThrowableHandler.php
+++ b/src/Provide/Error/ThrowableHandler.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace BEAR\Sunday\Provide\Error;
 
+use BEAR\Resource\Exception\BadRequestException;
+use BEAR\Resource\Exception\JsonSchemaRequestException;
 use BEAR\Sunday\Extension\Error\ErrorInterface;
 use BEAR\Sunday\Extension\Error\ThrowableHandlerInterface;
 use BEAR\Sunday\Extension\Router\RouterMatch as Request;
@@ -27,6 +29,10 @@ final class ThrowableHandler implements ThrowableHandlerInterface
     {
         if ($e instanceof Error) {
             $e = new ErrorException($e->getMessage(), $e->getCode(), E_ERROR, $e->getFile(), $e->getLine(), $e);
+        }
+
+        if ($e instanceof JsonSchemaRequestException) {
+            $e = new BadRequestException($e->getMessage(), $e->getCode(), $e);
         }
 
         /** @var Exception $e */

--- a/tests/Provide/Error/ThrowableHandlerTest.php
+++ b/tests/Provide/Error/ThrowableHandlerTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace BEAR\Sunday\Provide\Error;
 
+use BEAR\Resource\Exception\JsonSchemaRequestException;
+use BEAR\Resource\Exception\JsonSchemaResponseException;
 use BEAR\Resource\Exception\ResourceNotFoundException;
 use BEAR\Sunday\Extension\Router\RouterMatch;
 use BEAR\Sunday\Provide\Transfer\ConditionalResponse;
@@ -34,6 +36,22 @@ class ThrowableHandlerTest extends TestCase
         $this->assertSame(404, FakeHttpResponder::$code);
         $this->assertSame([['Content-Type: application/vnd.error+json', false]], FakeHttpResponder::$headers);
         $this->assertSame('{"message":"Not Found"}', FakeHttpResponder::$body);
+    }
+
+    public function testJsonSchemaRequestException(): void
+    {
+        $e = new JsonSchemaRequestException('title is required');
+        $this->throableHandler->handle($e, new RouterMatch())->transfer();
+        $this->assertSame(400, FakeHttpResponder::$code);
+        $this->assertSame([['Content-Type: application/vnd.error+json', false]], FakeHttpResponder::$headers);
+        $this->assertSame('{"message":"Bad Request"}', FakeHttpResponder::$body);
+    }
+
+    public function testJsonSchemaResponseException(): void
+    {
+        $e = new JsonSchemaResponseException('response does not match schema');
+        $this->throableHandler->handle($e, new RouterMatch())->transfer();
+        $this->assertSame(500, FakeHttpResponder::$code);
     }
 
     public function testError(): void


### PR DESCRIPTION
## Summary

- Raise `bear/resource` requirement from `^1.16` to `^1.33`
- In `ThrowableHandler::handle()`, convert `JsonSchemaRequestException` to `BadRequestException` (code 400) so `VndError` emits the correct 4xx response instead of the generic 500
- `JsonSchemaResponseException` (server-side schema mismatch) continues to produce a 500 — no change needed
- Tests added for both exception types

## Test plan

- [ ] `testJsonSchemaRequestException` → 400 with `application/vnd.error+json`
- [ ] `testJsonSchemaResponseException` → 500
- [ ] Existing `testException` (404) and `testError` (PHP Error → 500) still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)